### PR TITLE
Add a few useful plugins

### DIFF
--- a/serialization_spec/plugins.py
+++ b/serialization_spec/plugins.py
@@ -1,0 +1,77 @@
+from django.db.models import Count
+from .serialization import SerializationSpecPlugin
+
+
+class SerializationSpecPluginModel(SerializationSpecPlugin):
+    """ Derive from this if you want to apply model a function """
+
+    def __init__(self, relation):
+        self.relation = relation
+
+    def get_name(self):
+        return '%s_%s' % (self.relation, self.name)
+
+    def modify_queryset(self, queryset):
+        return queryset.annotate(**{self.get_name(): self.model_function(self.relation)})
+
+    def get_value(self, instance):
+        return getattr(instance, self.get_name())
+
+
+class CountOf(SerializationSpecPluginModel):
+    name = 'count'
+    model_function = Count
+
+
+class Exists(CountOf):
+    def get_value(self, instance):
+        return super().get_value(instance) > 0
+
+
+def extend_queryset(queryset, fields):
+    # This the means by which an already-`.only()`d queryset can be extended with more fields
+    existing, defer = queryset.query.deferred_loading
+    existing_set = set(existing)
+    existing_set.update(fields)
+    queryset.query.deferred_loading = (frozenset(existing_set), defer)
+
+
+class Requires(SerializationSpecPlugin):
+    """ Use this for a property which needs some underlying fields to be loaded """
+
+    def __init__(self, fields):
+        self.fields
+
+    def modify_queryset(self, queryset):
+        extend_queryset(queryset, self.fields)
+        return queryset
+
+    def get_value(self, instance):
+        return getattr(instance, self.key)
+
+
+class Transform(SerializationSpecPlugin):
+    """ Derive from this if you want to transform underlying data """
+
+    def modify_queryset(self, queryset):
+        extend_queryset(queryset, {self.key})
+        return queryset
+
+    def get_value(self, instance):
+        return self.transform(getattr(instance, self.key))
+
+    def transform(self, value):
+        raise NotImplementedError
+
+
+class MethodCall(SerializationSpecPlugin):
+    def __init__(self, name, required_fields=None):
+        self.name = name
+        self.required_fields = set(required_fields) or {}
+
+    def modify_queryset(self, queryset):
+        extend_queryset(queryset, self.required_fields)
+        return queryset
+
+    def get_value(self, instance):
+        return getattr(instance, self.name)()

--- a/serialization_spec/serialization.py
+++ b/serialization_spec/serialization.py
@@ -1,4 +1,4 @@
-from django.db.models import Prefetch, Count
+from django.db.models import Prefetch
 from rest_framework.utils import model_meta
 from rest_framework.fields import Field
 from rest_framework.serializers import ModelSerializer
@@ -148,38 +148,19 @@ class SerializationSpecMixin(QueriesDisabledViewMixin):
         return make_serializer_class(self.queryset.model, self.serialization_spec)
 
 
-class SerializationSpecPluginModel(SerializationSpecPlugin):
-    def __init__(self, relation):
-        self.relation = relation
-
-    def get_name(self):
-        return '%s_%s' % (self.relation, self.name)
-
-    def modify_queryset(self, queryset):
-        return queryset.annotate(**{self.get_name(): self.model_function(self.relation)})
-
-    def get_value(self, instance):
-        return getattr(instance, self.get_name())
-
-
-class CountOf(SerializationSpecPluginModel):
-    name = 'count'
-    model_function = Count
-
-
 """
 serialization_spec type should be
 
-    SerializationSpec = List[Union[str, Dict[str, Union[SerializationSpecPluginModel, 'SerializationSpec']]]]
+    SerializationSpec = List[Union[str, Dict[str, Union[SerializationSpecPlugin, 'SerializationSpec']]]]
 
 But recursive types are not yet implemented :(
 So we specify to an (arbitrary) depth of 5
 """
-SerializationSpec = List[Union[str, Dict[str, Union[SerializationSpecPluginModel,
-    List[Union[str, Dict[str, Union[SerializationSpecPluginModel,
-        List[Union[str, Dict[str, Union[SerializationSpecPluginModel,
-            List[Union[str, Dict[str, Union[SerializationSpecPluginModel,
-                List[Union[str, Dict[str, Union[SerializationSpecPluginModel,
+SerializationSpec = List[Union[str, Dict[str, Union[SerializationSpecPlugin,
+    List[Union[str, Dict[str, Union[SerializationSpecPlugin,
+        List[Union[str, Dict[str, Union[SerializationSpecPlugin,
+            List[Union[str, Dict[str, Union[SerializationSpecPlugin,
+                List[Union[str, Dict[str, Union[SerializationSpecPlugin,
                     List]]]]
             ]]]]
         ]]]]

--- a/tests/views.py
+++ b/tests/views.py
@@ -1,5 +1,6 @@
 from rest_framework import generics
-from serialization_spec.serialization import SerializationSpecMixin, CountOf
+from serialization_spec.serialization import SerializationSpecMixin
+from serialization_spec.plugins import CountOf
 from .models import Teacher, Student, Class, Subject, School, Assignment
 
 


### PR DESCRIPTION
Address https://github.com/dabapps/django-rest-framework-serialization-spec/issues/2 and https://github.com/dabapps/django-rest-framework-serialization-spec/issues/1

### Requires

If you have a property on a model which requires other fields to have been loaded:

```python
class Activity(models.Model):
    is_suspended = models.BooleanField()

    @property
    def status(self):
        return "SUSPENDED" if self.is_suspended else return "LIVE"
```

Instead of forcing the field to be loaded by explicitly serializing it:

```python
    serialization_spec = [
        'is_suspended',  # Needed by Activity.status
        'status',
        # ...
      ]
```

you can make the dependency explicit:

```python
    serialization_spec = [
        {'status': Requires(['is_suspended'])}
    ]
```

### MethodCall

If its a method call:

```python
class Activity(models.Model):
    is_suspended = models.BooleanField()

    def get_status(self):
        return "SUSPENDED" if self.is_suspended else return "LIVE"
```

you can use `MethodCall`:

```python
    serialization_spec = [
        {'status': MethodCall('get_status', required_fields=['is_suspended'])}
    ]
```

### Exists, CountOf

You can also do counts and exists of related collections like this:

```python
    serialization_spec = [
        {'has_cats': Exists('cats')},
        {'num_cats': CountOf('cats')},
    ]
```

### Transform

and apply arbitrary programmatic transformations by extending `Transform`:

```python
import json
class ParseJson(Transform):
    def transform(self, value):
        return json.loads(value)

    serialization_spec = [
        {'some_data': ParseJson()},
    ]
```
