### PR TITLE
If a plugin has a serialization_spec member then use that to extend the queryset

### DIFF
--- a/serialization_spec/plugins.py
+++ b/serialization_spec/plugins.py
@@ -1,5 +1,6 @@
 from django.db.models import Count
 from .serialization import SerializationSpecPlugin
+from .utils import extend_queryset
 
 
 class SerializationSpecPluginModel(SerializationSpecPlugin):
@@ -26,14 +27,6 @@ class CountOf(SerializationSpecPluginModel):
 class Exists(CountOf):
     def get_value(self, instance):
         return super().get_value(instance) > 0
-
-
-def extend_queryset(queryset, fields):
-    # This the means by which an already-`.only()`d queryset can be extended with more fields
-    existing, defer = queryset.query.deferred_loading
-    existing_set = set(existing)
-    existing_set.update(fields)
-    queryset.query.deferred_loading = (frozenset(existing_set), defer)
 
 
 class Requires(SerializationSpecPlugin):

--- a/serialization_spec/utils.py
+++ b/serialization_spec/utils.py
@@ -1,0 +1,6 @@
+def extend_queryset(queryset, fields):
+    """ Extend an already-`.only()`d queryset with more fields """
+    existing, defer = queryset.query.deferred_loading
+    existing_set = set(existing)
+    existing_set.update(fields)
+    queryset.query.deferred_loading = (frozenset(existing_set), defer)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -255,7 +255,7 @@ class DetailViewTestCase(SerializationSpecTestCase):
         self.assertJsonEqual(
             [query['sql'] for query in capture.captured_queries],
             [
-                "SELECT \"tests_assignment\".\"id\", \"tests_assignment\".\"name\" FROM \"tests_assignment\" WHERE \"tests_assignment\".\"id\" = '00000000-0000-0000-0000-000000000020'::uuid",
+                "SELECT \"tests_assignment\".\"id\", \"tests_assignment\".\"name\", \"tests_assignment\".\"clasz_id\", \"tests_class\".\"id\", \"tests_class\".\"created\", \"tests_class\".\"modified\", \"tests_class\".\"subject_id\", \"tests_class\".\"name\", \"tests_class\".\"teacher_id\", \"tests_teacher\".\"id\", \"tests_teacher\".\"created\", \"tests_teacher\".\"modified\", \"tests_teacher\".\"name\", \"tests_teacher\".\"school_id\" FROM \"tests_assignment\" INNER JOIN \"tests_class\" ON (\"tests_assignment\".\"clasz_id\" = \"tests_class\".\"id\") INNER JOIN \"tests_teacher\" ON (\"tests_class\".\"teacher_id\" = \"tests_teacher\".\"id\") WHERE \"tests_assignment\".\"id\" = '00000000-0000-0000-0000-000000000020'::uuid",
                 "SELECT (\"tests_assignmentstudent\".\"assignment_id\") AS \"_prefetch_related_val_assignment_id\", \"tests_student\".\"id\", \"tests_student\".\"name\", COUNT(\"tests_student_classes\".\"class_id\") AS \"classes_count\" FROM \"tests_student\" LEFT OUTER JOIN \"tests_student_classes\" ON (\"tests_student\".\"id\" = \"tests_student_classes\".\"student_id\") INNER JOIN \"tests_assignmentstudent\" ON (\"tests_student\".\"id\" = \"tests_assignmentstudent\".\"student_id\") WHERE \"tests_assignmentstudent\".\"assignment_id\" IN ('00000000-0000-0000-0000-000000000020'::uuid) GROUP BY (\"tests_assignmentstudent\".\"assignment_id\"), \"tests_student\".\"id\"",
                 "SELECT (\"tests_student_classes\".\"student_id\") AS \"_prefetch_related_val_student_id\", \"tests_class\".\"id\" FROM \"tests_class\" INNER JOIN \"tests_student_classes\" ON (\"tests_class\".\"id\" = \"tests_student_classes\".\"class_id\") WHERE \"tests_student_classes\".\"student_id\" IN ('00000000-0000-0000-0000-000000000015'::uuid)",
             ]
@@ -275,6 +275,7 @@ class DetailViewTestCase(SerializationSpecTestCase):
                     ]
                 }
             ],
+            "class_name": "Math B - Mr Cat",
         })
 
 

--- a/tests/views.py
+++ b/tests/views.py
@@ -1,5 +1,5 @@
 from rest_framework import generics
-from serialization_spec.serialization import SerializationSpecMixin
+from serialization_spec.serialization import SerializationSpecMixin, SerializationSpecPlugin
 from serialization_spec.plugins import CountOf
 from .models import Teacher, Student, Class, Subject, School, Assignment
 
@@ -134,6 +134,20 @@ class StudentWithAssignmentsDetailView(SerializationSpecMixin, generics.Retrieve
     ]
 
 
+class ClassName(SerializationSpecPlugin):
+    serialization_spec = [
+        {'clasz': [
+            'name',
+            {'teacher': [
+                'name'
+            ]},
+        ]},
+    ]
+
+    def get_value(self, instance):
+        return '%s - %s' % (instance.clasz.name, instance.clasz.teacher.name)
+
+
 class AssignmentDetailView(SerializationSpecMixin, generics.RetrieveAPIView):
 
     queryset = Assignment.objects.all()
@@ -147,5 +161,6 @@ class AssignmentDetailView(SerializationSpecMixin, generics.RetrieveAPIView):
             'name',
             {'classes_count': CountOf('classes')},
             'classes',
-        ]}
+        ]},
+        {'class_name': ClassName()}
     ]


### PR DESCRIPTION
https://github.com/dabapps/django-rest-framework-serialization-spec/issues/21

Sometimes is a tidier way to specify the way the queryset should be extended than implementing `modify_queryset()`