### PR TITLE
Make request_user available in SerializationSpecPlugins

### DIFF
--- a/serialization_spec/serialization.py
+++ b/serialization_spec/serialization.py
@@ -189,9 +189,10 @@ class NormalisedSpec:
         self.relations = OrderedDict()
 
 
-def normalise_spec(serialization_spec):
+def normalise_spec(serialization_spec, request_user=None):
     def normalise(spec, normalised_spec):
         if isinstance(spec, SerializationSpecPlugin) or isinstance(spec, Filtered):
+            spec.request_user = request_user
             normalised_spec.spec = spec
             return
 
@@ -228,7 +229,7 @@ class SerializationSpecMixin(QueriesDisabledViewMixin):
     def get_queryset(self):
         queryset = self.queryset
         serialization_spec = expand_nested_specs(self.serialization_spec)
-        serialization_spec = normalise_spec(serialization_spec)
+        serialization_spec = normalise_spec(serialization_spec, self.request.user)
         queryset = queryset.only(*get_only_fields(queryset.model, serialization_spec))
         queryset = prefetch_related(queryset, queryset.model, [], serialization_spec, getattr(self, 'use_select_related', False))
         return queryset

--- a/serialization_spec/serialization.py
+++ b/serialization_spec/serialization.py
@@ -189,7 +189,7 @@ class NormalisedSpec:
         self.relations = OrderedDict()
 
 
-def normalise_spec(serialization_spec, request_user=None):
+def normalise_spec(serialization_spec, request_user):
     def normalise(spec, normalised_spec):
         if isinstance(spec, SerializationSpecPlugin) or isinstance(spec, Filtered):
             spec.request_user = request_user

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -347,7 +347,7 @@ class NormalisationTestCase(TestCase):
             {'four': []},
         ]
 
-        self.assertEqual(normalise_spec(spec), [
+        self.assertEqual(normalise_spec(spec, None), [
             'one',
             {
                 'two': [
@@ -366,7 +366,7 @@ class NormalisationTestCase(TestCase):
             'one',
         ]
 
-        self.assertEqual(normalise_spec(spec), [
+        self.assertEqual(normalise_spec(spec, None), [
             'one',
             {'two': [
                 'three',
@@ -384,7 +384,7 @@ class NormalisationTestCase(TestCase):
             ]},
         ]
 
-        self.assertEqual(normalise_spec(spec), [
+        self.assertEqual(normalise_spec(spec, None), [
             'one',
             {'two': [
                 'three',
@@ -409,7 +409,7 @@ class NormalisationTestCase(TestCase):
             ]},
         ]
 
-        self.assertEqual(normalise_spec(spec), [
+        self.assertEqual(normalise_spec(spec, None), [
             'one',
             {'two': [
                 'four',


### PR DESCRIPTION
As a convenience, in case plugins need to compare fields against request user