### PR TITLE
For a reverse many-to-many relation we should not (cannot) prefetch the reverse FK

### DIFF
--- a/serialization_spec/serialization.py
+++ b/serialization_spec/serialization.py
@@ -179,7 +179,9 @@ def prefetch_related(request_user, queryset, model, prefixes, serialization_spec
                                 for rel in model._meta.related_objects
                                 if rel.get_accessor_name() == key
                             )
-                            only_fields += ['%s_id' % reverse_fk]
+                            has_reverse_fk = any(field.name == reverse_fk for field in relation.related_model._meta.fields)
+                            if has_reverse_fk:
+                                only_fields += ['%s_id' % reverse_fk]
                         inner_queryset = prefetch_related(request_user, related_model.objects.only(*only_fields), related_model, [], childspec, use_select_related)
                         if filters:
                             inner_queryset = inner_queryset.filter(filters).distinct()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -130,7 +130,7 @@ class DetailViewTestCase(SerializationSpecTestCase):
             ],
         })
 
-    def test_single_fk_on_fk(self):
+    def test_single_fk_on_fk_and_reverse_m2m(self):
         with CaptureQueriesContext(connection) as capture:
             url = reverse('class-detail', kwargs={'id': str(self.math_class.id)})
             response = self.client.get(url)
@@ -138,7 +138,8 @@ class DetailViewTestCase(SerializationSpecTestCase):
         self.assertJsonEqual(
             sorted(query['sql'] for query in capture.captured_queries),
             [
-                """SELECT "tests_class"."id", "tests_class"."name", "tests_class"."teacher_id", "tests_teacher"."id", "tests_teacher"."created", "tests_teacher"."modified", "tests_teacher"."name", "tests_teacher"."school_id", "tests_school"."id", "tests_school"."created", "tests_school"."modified", "tests_school"."name", "tests_school"."lea_id" FROM "tests_class" INNER JOIN "tests_teacher" ON ("tests_class"."teacher_id" = "tests_teacher"."id") INNER JOIN "tests_school" ON ("tests_teacher"."school_id" = "tests_school"."id") WHERE "tests_class"."id" = '00000000-0000-0000-0000-000000000006'::uuid"""
+                """SELECT "tests_class"."id", "tests_class"."name", "tests_class"."teacher_id", "tests_teacher"."id", "tests_teacher"."created", "tests_teacher"."modified", "tests_teacher"."name", "tests_teacher"."school_id", "tests_school"."id", "tests_school"."created", "tests_school"."modified", "tests_school"."name", "tests_school"."lea_id" FROM "tests_class" INNER JOIN "tests_teacher" ON ("tests_class"."teacher_id" = "tests_teacher"."id") INNER JOIN "tests_school" ON ("tests_teacher"."school_id" = "tests_school"."id") WHERE "tests_class"."id" = '00000000-0000-0000-0000-000000000006'::uuid""",
+                """SELECT ("tests_student_classes"."class_id") AS "_prefetch_related_val_class_id", "tests_student"."id", "tests_student"."name" FROM "tests_student" INNER JOIN "tests_student_classes" ON ("tests_student"."id" = "tests_student_classes"."student_id") WHERE "tests_student_classes"."class_id" IN ('00000000-0000-0000-0000-000000000006'::uuid)"""
             ]
         )
 
@@ -153,6 +154,9 @@ class DetailViewTestCase(SerializationSpecTestCase):
                     "name": "Kitteh High"
                 },
             },
+            'student_set': [
+                {'name': 'Student 3'}, {'name': 'Student 4'}, {'name': 'Student 5'}, {'name': 'Student 6'}, {'name': 'Student 7'}, {'name': 'Student 8'}, {'name': 'Student 9'},
+            ]
         })
 
     def test_single_fk_on_many_to_many(self):

--- a/tests/views.py
+++ b/tests/views.py
@@ -72,7 +72,10 @@ class ClassDetailView(SerializationSpecMixin, generics.RetrieveAPIView):
                 'id',
                 'name'
             ]}
-        ]}
+        ]},
+        {'student_set': [
+            'name',
+        ]},
     ]
 
 


### PR DESCRIPTION
Bug discovered by @CharlieHarle which prevented fetching reverse many-to-many relations.

Eg this did not work:

```python
class User(Model):
    id = UUIDField(primary_key=True, default=uuid.uuid4, editable=False)

class UserGroup(Model):
    users = ManyToManyField(User, blank=True)

class UsersList(SerializationSpecMixin, ListAPIView):
    queryset = User.objects.all()
    serialization_spec = [
        {'usergroup_set': [
            'id',
            'name'
        ]}
    ]
```

because it would try to prefetch `users_id` on the related `UserGroup` which isn't possible and  fails with:

`django.core.exceptions.FieldDoesNotExist: UserGroup has no field named 'users_id'`