### PR TITLE
Colliding M2M fields

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Django==1.11.17
 djangorestframework==3.5.3
-django-zen-queries==1.0.0
+django-zen-queries==1.1.0

--- a/serialization_spec/serialization.py
+++ b/serialization_spec/serialization.py
@@ -114,7 +114,6 @@ def handle_filtered(item):
 def make_serializer_class(model, serialization_spec):
     relations = model_meta.get_field_info(model).relations
 
-
     return type(
         'MySerializer',
         (ModelSerializer,),
@@ -255,15 +254,19 @@ def expand_many2many_id_fields(model, serialization_spec):
     relations = model_meta.get_field_info(model).relations
 
     for idx, each in enumerate(serialization_spec):
-        if not isinstance(each, dict) and each in relations:
-            relation = relations[each]
-            related_model = relation.related_model
-
-            if isinstance(each, dict):
-                for key, childspec in each.items():
-                    expand_many2many_id_fields(related_model, childspec)
-            elif relation.to_many:
-                serialization_spec[idx] = {each: ManyToManyIDsPlugin(related_model, each)}
+        if not isinstance(each, dict):
+            if each in relations:
+                relation = relations[each]
+                related_model = relation.related_model
+                if relation.to_many:
+                    serialization_spec[idx] = {each: ManyToManyIDsPlugin(related_model, each)}
+        else:
+            for key, childspec in each.items():
+                if key in relations:
+                    relation = relations[key]
+                    related_model = relation.related_model
+                    if relation.to_many:
+                        expand_many2many_id_fields(related_model, childspec)
 
 
 class SerializationSpecMixin(QueriesDisabledViewMixin):

--- a/serialization_spec/serialization.py
+++ b/serialization_spec/serialization.py
@@ -103,6 +103,11 @@ def handle_filtered(item):
 def make_serializer_class(model, serialization_spec):
     relations = model_meta.get_field_info(model).relations
 
+    def make_id_list_getter(key):
+        def id_list_getter(value):
+            return [str(each.id) for each in getattr(value, key).all()]
+        return id_list_getter
+
     return type(
         'MySerializer',
         (ModelSerializer,),
@@ -113,7 +118,7 @@ def make_serializer_class(model, serialization_spec):
                 {'model': model, 'fields': get_fields(serialization_spec)}
             ),
             **{
-                key: SerializerLambdaField(impl=lambda value: [str(each.id) for each in getattr(value, key).all()])
+                key: SerializerLambdaField(impl=make_id_list_getter(key))
                 for key in get_only_fields(model, serialization_spec)
                 if key in relations and relations[key].to_many
             },

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -423,3 +423,23 @@ class NormalisationTestCase(TestCase):
                 ]}
             ]}
         ])
+
+
+class CollidingFieldsRegressionTestCase(SerializationSpecTestCase):
+
+    def test_multiple_many_to_many_fields_do_not_collide(self):
+        url = reverse('student-with-classes-and-assignments-detail', kwargs={'id': str(self.student.id)})
+        response = self.client.get(url)
+
+        self.assertJsonEqual(response.data, {
+            'id': uuid('15'),
+            'name': 'Student 5',
+            "assignments": [
+                {"name": "French A Assignment"},
+                {"name": "Math B Assignment"},
+            ],
+            "classes": [
+                {"name": "French A"},
+                {"name": "Math B"},
+            ],
+        })

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -435,11 +435,11 @@ class CollidingFieldsRegressionTestCase(SerializationSpecTestCase):
             'id': uuid('15'),
             'name': 'Student 5',
             "assignments": [
-                {"name": "French A Assignment"},
-                {"name": "Math B Assignment"},
+                uuid('21'),
+                uuid('20'),
             ],
             "classes": [
-                {"name": "French A"},
-                {"name": "Math B"},
+                uuid('5'),
+                uuid('6'),
             ],
         })

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -10,4 +10,5 @@ urlpatterns = [
     url(r'^schools/(?P<id>[0-9a-f-]+)/$', view=views.SchoolDetailView.as_view(), name='school-detail'),
     url(r'^students-detail/(?P<id>[0-9a-f-]+)/$', view=views.StudentWithAssignmentsDetailView.as_view(), name='student-with-assignments-detail'),
     url(r'^assignments/(?P<id>[0-9a-f-]+)/$', view=views.AssignmentDetailView.as_view(), name='assignment-detail'),
+    url(r'^students-with-classes-and-assignments/(?P<id>[0-9a-f-]+)/$', view=views.StudentWithClassesAndAssignmentsDetailView.as_view(), name='student-with-classes-and-assignments-detail'),
 ]

--- a/tests/views.py
+++ b/tests/views.py
@@ -170,3 +170,20 @@ class AssignmentDetailView(SerializationSpecMixin, generics.RetrieveAPIView):
             {'num_students': CountOf('student')},
         ]},
     ]
+
+
+class StudentWithClassesAndAssignmentsDetailView(SerializationSpecMixin, generics.RetrieveAPIView):
+
+    queryset = Student.objects.all()
+    lookup_field = 'id'
+
+    serialization_spec = [
+        'id',
+        'name',
+        {'assignments': [
+            'name'
+        ]},
+        {'classes': [
+            'name'
+        ]},
+    ]

--- a/tests/views.py
+++ b/tests/views.py
@@ -180,10 +180,6 @@ class StudentWithClassesAndAssignmentsDetailView(SerializationSpecMixin, generic
     serialization_spec = [
         'id',
         'name',
-        {'assignments': [
-            'name'
-        ]},
-        {'classes': [
-            'name'
-        ]},
+        'assignments',
+        'classes',
     ]


### PR DESCRIPTION
This is an attempt to isolate and fix #57 

At the moment, we have a test case which attempts to capture the problem - but it actually passes at the moment, so it mustn't be right. The issue does specify that the problem only appears for "id-list fields", but I've also tried with `id` instead of `name` and the functionality still seems to work.