### PR TITLE
Revert "Use Django's exists aggregation logic for exists"

### DIFF
--- a/serialization_spec/plugins.py
+++ b/serialization_spec/plugins.py
@@ -1,5 +1,5 @@
 from typing import Dict, Any
-from django.db.models import Count, Exists as DjangoExists
+from django.db.models import Count
 from .serialization import SerializationSpecPlugin
 from .utils import extend_queryset
 
@@ -27,9 +27,9 @@ class CountOf(SerializationSpecPluginModel):
     kwargs = {'distinct': True}  # To prevent counts clashing with each other
 
 
-class Exists(SerializationSpecPluginModel):
-    name = 'exists'
-    model_function = DjangoExists
+class Exists(CountOf):
+    def get_value(self, instance):
+        return super().get_value(instance) > 0
 
 
 class Requires(SerializationSpecPlugin):


### PR DESCRIPTION
Reverts dabapps/django-rest-framework-serialization-spec#59

So turns out `Exists` is a subquery, not an aggregation, which means it can't be used in the same way as `Count`.

Exactly how to correctly modify the queryset for separate subqueries like that looks like it might be pretty complex, especially for `n` levels of nesting. So for now revert back to the old logic, so it works and doesn't crash!

Test yo' changes, kids!